### PR TITLE
Added the ability to supply custom config file

### DIFF
--- a/displayserver.js
+++ b/displayserver.js
@@ -1,6 +1,20 @@
 var connect = require('connect');
 var serveStatic = require('serve-static');
-var port = 1391;
-connect().use(serveStatic(__dirname)).listen(port);
+var argumentAliases = {'port' : 'p', 'config' : 'c'};
+var argv = require('minimist')(process.argv.slice(2), {alias : argumentAliases});
+var path = require('path');
+var send = require('send');
+
+var port = argv.port || 1391;
+var configFile = argv.config ? path.resolve(argv.config) : path.resolve(path.dirname(process.argv[1]), 'config.js');
+
+
+var app = connect();
+app.use('/config.js', function (req, res) {
+    send(req, configFile).pipe(res);
+});
+
+app.use(serveStatic(__dirname));
+app.listen(port);
 console.log('server running on port',port);
 console.log('open browser to http://localhost:'+port+'/');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "homepage": "https://github.com/FirstLegoLeague/displaySystem#readme",
   "dependencies": {
     "connect": "^3.5.0",
+    "minimist": "^1.2.0",
+    "send": "^0.15.4",
     "serve-static": "^1.11.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Luckily, we have already done this for you, but there is a catch. The control wi
     - type `npm install`
     - type `npm start`
     - you can now open the application by navigating to <http://localhost:1391>
+    - node has the advantage of taking arguments- you can specify a custom config file with `--config` or a custom port with `--port`. Shorthand arguments are also accepted.
 - Lastly, you can also control the display system by other means, but this gets more complicated. More on that below.
 
 So, the control window. To open it, press `c`


### PR DESCRIPTION
Using option flag '--config' you can now supply a config file to be used instead of the default config.js. Also added a '-p' flag to specify port, with the default being the old 1391.